### PR TITLE
fix: prevent race condition in rapid language changes

### DIFF
--- a/src/components/language-provider.tsx
+++ b/src/components/language-provider.tsx
@@ -25,7 +25,7 @@ export const LanguageProvider = ({ children }: LanguageProviderProps) => {
 
   const changeLanguage = async (newLanguage: Language) => {
     await i18n.changeLanguage(newLanguage)
-    setLanguage(newLanguage)
+    setLanguage(i18n.language as Language)
   }
 
   return (


### PR DESCRIPTION
Use i18n.language as source of truth after changeLanguage completes instead of relying on the requested newLanguage parameter. This ensures state consistency even when changeLanguage is called multiple times rapidly, as React state will always reflect i18n's actual current language rather than potentially outdated request parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)