### PR TITLE
fix: SEO improvements and HelmetProvider fix

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
+import { HelmetProvider } from '@dr.pogodin/react-helmet'
 import '@/index.css'
 import '@/i18n/config'
 import { LanguageProvider } from '@/components/language-provider'
@@ -17,12 +18,14 @@ declare module '@tanstack/react-router' {
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <Suspense fallback={<div>Loading...</div>}>
-      <ThemeProvider>
-        <LanguageProvider>
-          <RouterProvider router={router} />
-        </LanguageProvider>
-      </ThemeProvider>
-    </Suspense>
+    <HelmetProvider>
+      <Suspense fallback={<div>Loading...</div>}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <RouterProvider router={router} />
+          </LanguageProvider>
+        </ThemeProvider>
+      </Suspense>
+    </HelmetProvider>
   </StrictMode>
 )


### PR DESCRIPTION
## Summary
- Remove redundant `x-default` hreflang tag (not applicable for client-side i18n)
- Add missing `HelmetProvider` wrapper to fix deployment error

## Test plan
- [ ] Verify no Helmet errors in browser console
- [ ] Verify SEO meta tags render correctly
- [ ] Test in both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)